### PR TITLE
Address the issue related to url validation

### DIFF
--- a/app/src/main/java/io/kuenzler/whatsappwebtogo/WebviewActivity.java
+++ b/app/src/main/java/io/kuenzler/whatsappwebtogo/WebviewActivity.java
@@ -234,14 +234,14 @@ public class WebviewActivity extends AppCompatActivity implements NavigationView
 
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
-                final String url = request.getUrl().toString();
-                Log.d(DEBUG_TAG, url);
+                Uri url = request.getUrl();
+                Log.d(DEBUG_TAG, url.toString());
 
-                if (request.getUrl().getHost().equals("web.whatsapp.com")) {
+                if (url.getHost().equals("web.whatsapp.com")) {
                     // whatsapp web request -> fine
                     return super.shouldOverrideUrlLoading(view, request);
                 } else {
-                    Intent intent = new Intent(Intent.ACTION_VIEW, request.getUrl());
+                    Intent intent = new Intent(Intent.ACTION_VIEW, url);
                     startActivity(intent);
                     return true;
                 }

--- a/app/src/main/java/io/kuenzler/whatsappwebtogo/WebviewActivity.java
+++ b/app/src/main/java/io/kuenzler/whatsappwebtogo/WebviewActivity.java
@@ -237,7 +237,7 @@ public class WebviewActivity extends AppCompatActivity implements NavigationView
                 final String url = request.getUrl().toString();
                 Log.d(DEBUG_TAG, url);
 
-                if (url.contains("web.whatsapp.com")) {
+                if (request.getUrl().getHost().equals("web.whatsapp.com")) {
                     // whatsapp web request -> fine
                     return super.shouldOverrideUrlLoading(view, request);
                 } else {


### PR DESCRIPTION
Good afternoon Leonhard,

Your repository WhatsappWebToGo is a very popular one with many stars and forks, which is a nice project helping the open source community to develop Android apps with webviews.

I noticed an issue that its URL validation has a flaw, which doesn't validate the full domain. Currently it checks:
> url.contains("web.whatsapp.com")

With this implementation, the validation will succeed as long as the text `web.whatsapp.com` is in the hostname or path portion of the Uri. For example, the following URLs in the domain of `example.com` will be trusted:
```
https://web.whatsapp.comabc.example.com/anypath/page1.do
https://www.example.com/web.whatsapp.com/page1.do
```
I think the desired behaviour is:
> request.getUrl().getHost().equals("web.whatsapp.com")

Would you please investigate and merge my pull request if you agree?

Thanks @92lleo in advance for looking into this pull request.

Luc