### PR TITLE
Fix spelling, punctuation and capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WhatsappWebToGo
+# WhatsApp Web To Go
 
 Mobile Client for WhatsApp Web.
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
 # WhatsappWebToGo
 
-Mobile Client for WhatsappWeb
+Mobile Client for WhatsApp Web.
+
 This app lets you access WhatsApp Web on your mobile phone or tablet.
-It has full support for sending audio and pictures / video.
+It has full support for sending audio and pictures/video.
 
 [<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
     alt="Get it on F-Droid"
     height="80">](https://f-droid.org/packages/io.kuenzler.whatsappwebtogo)
     
-You can also get the latest version from the releases tab. Please note, that the github and fdroid version are not compatible, as they are signed diffrently
+You can also get the latest version from the releases tab. Please note that the GitHub and F-Droid versions are not compatible, as they are signed differently.
 
--free and without ads-
+Free and without ads.
 
-If you have problems just send a mail or create a github issue
+If you have problems, just send a mail or create a GitHub issue.
 
-This was initially a proof of concept to try some things with the android webview. The app design is bad, i'll refactor it some time, maybe.
+This was initially a proof of concept to try some things with the Android WebView. The app design is bad; I'll refactor it some time, maybe.
 
 This app is in no way affiliated with WhatsApp Inc. The rights for WhatsApp and WhatsApp Web belong to WhatsApp Inc. 
-This app is a private project to enable the use of WhatsApp Web on Android Devices
+This app is a private project to enable the use of WhatsApp Web on Android devices.

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -4,7 +4,7 @@
 
     <string name="versionInfoText">Terima kasih telah memperbarui!\nYang baru di versi 1.7.2:\n&#8211;Fix download extension matcher\n&#8211;Make chat size fit phone screen (thanks @benehmb)</string>
     <string name="introInfoText">Terima kasih telah memasang aplikasi ini!\nTinggal menghubungkan ponsel Anda seperti yang Anda lakukan di komputer.\nUntuk mengunci dan membuka kunci papan ketik, gunakan tombol papan ketik di kanan atas. Pengaturan Anda akan disimpan.</string>
-    <string name="aboutText" translatable="false">WhatsappWeb To Go\n\nby Leonhard Künzler\nBasetwo GbR\nandroid@kuenzler.io\n\ngithub.com/92lleo/WhatsappWebToGo\n\n© 2017&#8211;2021\n\nv1.7.2\n\nThis app is in no way affiliated with WhatsApp Inc. The rights for WhatsApp and WhatsApp Web belong to WhatsApp Inc. This app is a private project to enable the use of WhatsApp Web on Android Devices</string>
+    <string name="aboutText" translatable="false">WhatsApp Web To Go\n\nby Leonhard Künzler\nBasetwo GbR\nandroid@kuenzler.io\n\ngithub.com/92lleo/WhatsappWebToGo\n\n© 2017&#8211;2021\n\nv1.7.2\n\nThis app is in no way affiliated with WhatsApp Inc. The rights for WhatsApp and WhatsApp Web belong to WhatsApp Inc. This app is a private project to enable the use of WhatsApp Web on Android devices.</string>
 
     <string name="navigation_drawer_open">Buka bilah navigasi</string>
     <string name="navigation_drawer_close">Tutup bilah navigasi</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
 
     <string name="versionInfoText">Thanks for updating!\nNew in version 1.7.2:\n&#8211;Fix download extension matcher\n&#8211;Make chat size fit phone screen (thanks @benehmb)</string>
     <string name="introInfoText">Thanks for installing!\nJust connect your phone as you would on your computer.\nTo lock and unlock the keyboard, use the keyboard button top right. Your settings will be saved.</string>
-    <string name="aboutText" translatable="false">WhatsappWeb To Go\n\nby Leonhard Künzler\nBasetwo GbR\nandroid@kuenzler.io\n\ngithub.com/92lleo/WhatsappWebToGo\n\n© 2017&#8211;2021\n\nv1.7.2\n\nThis app is in no way affiliated with WhatsApp Inc. The rights for WhatsApp and WhatsApp Web belong to WhatsApp Inc. This app is a private project to enable the use of WhatsApp Web on Android Devices</string>
+    <string name="aboutText" translatable="false">WhatsApp Web To Go\n\nby Leonhard Künzler\nBasetwo GbR\nandroid@kuenzler.io\n\ngithub.com/92lleo/WhatsappWebToGo\n\n© 2017&#8211;2021\n\nv1.7.2\n\nThis app is in no way affiliated with WhatsApp Inc. The rights for WhatsApp and WhatsApp Web belong to WhatsApp Inc. This app is a private project to enable the use of WhatsApp Web on Android devices.</string>
 
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>

--- a/fastlane/metadata/android/de/full_description.txt
+++ b/fastlane/metadata/android/de/full_description.txt
@@ -1,7 +1,7 @@
-<i>Whatsapp Web To Go</i> lässt dich WhatsApp Web auf dem Smartphone oder Tablet nutzen. Die App unterstützt das Verschicken von Bildern, Videos und Audio - über eine übersichtliche Oberfläche
+<i>WhatsApp Web To Go</i> lässt dich WhatsApp Web auf dem Smartphone oder Tablet nutzen. Die App unterstützt das Verschicken von Bildern, Videos und Audio - über eine übersichtliche Oberfläche
 
 -kostenlos und ohne Werbung-
 
-Bei Problemen sende bitte eine Mail oder erstelle ein Github Issue.
+Bei Problemen sende bitte eine Mail oder erstelle ein GitHub Issue.
 
-This app is in no way affiliated with WhatsApp Inc. The rights for WhatsApp and WhatsApp Web belong to WhatsApp Inc. This app is a private project to enable the use of WhatsApp Web on Android Devices.
+This app is in no way affiliated with WhatsApp Inc. The rights for WhatsApp and WhatsApp Web belong to WhatsApp Inc. This app is a private project to enable the use of WhatsApp Web on Android devices.

--- a/fastlane/metadata/android/de/title.txt
+++ b/fastlane/metadata/android/de/title.txt
@@ -1,1 +1,1 @@
-Whatsapp Web To Go - Client für Whatsapp Web
+WhatsApp Web To Go - Client für WhatsApp Web

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,7 +1,7 @@
-<i>Whatsapp Web To Go</i> lets you access WhatsApp Web on your mobile phone or tablet. It has full support for sending pictures, audio and video - with a clean and easy interface.
+<i>WhatsApp Web To Go</i> lets you access WhatsApp Web on your mobile phone or tablet. It has full support for sending pictures, audio and video - with a clean and easy interface.
 
--free and without ads-
+Free and without ads.
 
-If you have problems just send a mail or create a github issue.
+If you have problems, just send a mail or create a GitHub issue.
 
-This app is in no way affiliated with WhatsApp Inc. The rights for WhatsApp and WhatsApp Web belong to WhatsApp Inc. This app is a private project to enable the use of WhatsApp Web on Android Devices.
+This app is in no way affiliated with WhatsApp Inc. The rights for WhatsApp and WhatsApp Web belong to WhatsApp Inc. This app is a private project to enable the use of WhatsApp Web on Android devices.

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-Whatsapp Web To Go - Mobile Client for Whatsapp Web
+WhatsApp Web To Go - Mobile Client for WhatsApp Web

--- a/fastlane/metadata/android/id/full_description.txt
+++ b/fastlane/metadata/android/id/full_description.txt
@@ -1,7 +1,7 @@
-<i>Whatsapp Web To Go</i> memperbolehkan Anda mengakses WhatsApp Web di perangkat ponsel atau tablet. Aplikasi ini mempunyai dukungan penuh untuk mengirim gambar, audio, dan video - dengan tampilan yang bersih dan mudah.
+<i>WhatsApp Web To Go</i> memperbolehkan Anda mengakses WhatsApp Web di perangkat ponsel atau tablet. Aplikasi ini mempunyai dukungan penuh untuk mengirim gambar, audio, dan video - dengan tampilan yang bersih dan mudah.
 
 -gratis/bebas dan tanpa iklan-
 
 Jika Anda mempunyai masalah, tinggal kirim surel atau buat sebuah isu di GitHub.
 
-Aplikasi ini tidak terafiliasi sama sekali dengan WhatsApp Inc. Hak untuk WhatsApp dan WhatsApp Web dimiliki oleh WhatsApp Inc. Aplikasi ini adalah proyek pribadi untuk memperbolehkan penggunaan WhatsApp Web di perangkat Android
+Aplikasi ini tidak terafiliasi sama sekali dengan WhatsApp Inc. Hak untuk WhatsApp dan WhatsApp Web dimiliki oleh WhatsApp Inc. Aplikasi ini adalah proyek pribadi untuk memperbolehkan penggunaan WhatsApp Web di perangkat Android.

--- a/fastlane/metadata/android/id/title.txt
+++ b/fastlane/metadata/android/id/title.txt
@@ -1,1 +1,1 @@
-Whatsapp Web To Go - Klien Ponsel untuk Whatsapp Web
+WhatsApp Web To Go - Klien Ponsel untuk WhatsApp Web


### PR DESCRIPTION
I've tried changing as little as possible.

The actual app name appears to be "WhatsApp Web To Go", as defined in:
https://github.com/92lleo/WhatsappWebToGo/blob/e04049bee0f140660f32fcf65878d2b95db2b1b2/app/src/main/res/values/strings.xml#L2
I've edited some text files to reflect the correct app name.